### PR TITLE
fix: use keccak256-circom

### DIFF
--- a/circuits/circom-ecdsa-circuits/keccak-circom/keccak.circom
+++ b/circuits/circom-ecdsa-circuits/keccak-circom/keccak.circom
@@ -1,4 +1,7 @@
-pragma circom 2.0.2;
+// Keccak256 hash function (ethereum version).
+// For LICENSE check https://github.com/vocdoni/keccak256-circom/blob/master/LICENSE
+
+pragma circom 2.0.0;
 
 include "./utils.circom";
 include "./permutations.circom";

--- a/circuits/circom-ecdsa-circuits/keccak-circom/permutations.circom
+++ b/circuits/circom-ecdsa-circuits/keccak-circom/permutations.circom
@@ -1,4 +1,7 @@
-pragma circom 2.0.2;
+// Keccak256 hash function (ethereum version).
+// For LICENSE check https://github.com/vocdoni/keccak256-circom/blob/master/LICENSE
+
+pragma circom 2.0.0;
 
 include "./utils.circom";
 
@@ -793,4 +796,3 @@ template Iota(r) {
         out[i] <== in[i];
     }
 }
-

--- a/circuits/circom-ecdsa-circuits/keccak-circom/utils.circom
+++ b/circuits/circom-ecdsa-circuits/keccak-circom/utils.circom
@@ -1,8 +1,7 @@
-pragma circom 2.0.2;
+// Keccak256 hash function (ethereum version).
+// For LICENSE check https://github.com/vocdoni/keccak256-circom/blob/master/LICENSE
 
-include "../../../node_modules/circomlib/circuits/gates.circom";
-include "../../../node_modules/circomlib/circuits/sha256/xor3.circom";
-include "../../../node_modules/circomlib/circuits/sha256/shift.circom"; // contains ShiftRight
+pragma circom 2.0.0;
 
 template Xor5(n) {
     signal input a[n];
@@ -12,7 +11,7 @@ template Xor5(n) {
     signal input e[n];
     signal output out[n];
     var i;
-    
+
     component xor3 = Xor3(n);
     for (i=0; i<n; i++) {
         xor3.a[i] <== a[i];

--- a/circuits/circom-ecdsa-circuits/zk-identity/eth.circom
+++ b/circuits/circom-ecdsa-circuits/zk-identity/eth.circom
@@ -1,8 +1,11 @@
 pragma circom 2.0.2;
 
-include "../vocdoni-keccak/keccak.circom";
+include "../keccak-circom/keccak.circom";
 
 include "../../../node_modules/circomlib/circuits/bitify.circom";
+include "../../../node_modules/circomlib/circuits/gates.circom";
+include "../../../node_modules/circomlib/circuits/sha256/xor3.circom";
+include "../../../node_modules/circomlib/circuits/sha256/shift.circom";
 
 /*
  * Possibly generalizable, but for now just flatten a single pubkey from k n-bit chunks to a * single bit array


### PR DESCRIPTION
The `vocdoni-keccak` implementation fails with the private key `0x00554c162e41ab505bc0cc0818fc53940a9687dda3120cf7057576b32ed65344` during `ecdsa_verify_pubkey_to_addr`. Switching to [electron-labs/keccak-circom](https://github.com/Electron-Labs/keccak-circom) seems to fix it.